### PR TITLE
Docker build for standardizing packaging env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:8.7
+
+MAINTAINER Mael Auzias <docker@mael.auzias.net>
+
+LABEL Description="This image is used to run KeePassXC: cross platform community driven port of the windows application “Keepass Password Safe” (GPL) available at https://github.com/keepassxreboot/keepassxc"
+
+RUN apt-get update && apt-get install -y \
+      git ca-certificates \
+      build-essential cmake libmicrohttpd-dev libxi-dev libxtst-dev qtbase5-dev libqt5x11extras5-dev qttools5-dev qttools5-dev-tools libgcrypt20-dev zlib1g-dev \
+      --no-install-recommends \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV HOME /home/keepassxreboot
+ENV USER keepassxreboot
+
+RUN adduser -q --disabled-password $USER \
+ && chown -R $USER $HOME \
+ && cd /home/keepassxreboot \
+ && git clone https://github.com/keepassxreboot/keepassxc.git \
+ && cd keepassxc \
+ && cmake -DWITH_TESTS=OFF \
+ && make \
+ && make install
+
+WORKDIR $HOME
+USER $USER
+
+ENTRYPOINT keepassxc

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+# How to build the Docker image?
+To build the Docker image open a terminal in this directory and run the command: `docker build -t keepassxc[:tag]`. The optional tag may contain the version or the actual commit number.
+
+# How to run `keepassxc`?
+The following command:
+
+    docker run --rm -it -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v /etc/localtime:/etc/localtime -v /host/path/to/db-directory:/db keepassxc
+
+Will run `keepassxc`. The directory on the host named `/host/path/to/db-directory` will be mounted in the directory `/db` of the container. This should be used to keep a persistent database.


### PR DESCRIPTION
## Description
Originally produced by @auzias for [keepassxc/#190](https://github.com/keepassxreboot/keepassxc/pull/190)

The file `docker/Dockerfile` can be used to build a Docker image.
To build the image and run a container see the file `docker/README.md`.

## Motivation and Context
This change is required in order to provide a community manage Docker image.

## How Has This Been Tested?
The container has been tested using the commands shown in `docker/README.md`.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ I have read the **CONTRIBUTING** document. **[REQUIRED]**
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

