### PR TITLE
Updated keepassxc-cli.1 to a newer more up to date version

### DIFF
--- a/ubuntu-ppa/bionic/keepassxc/debian/keepassxc-cli.1
+++ b/ubuntu-ppa/bionic/keepassxc/debian/keepassxc-cli.1
@@ -1,53 +1,183 @@
-.TH KEEPASSXC-CLI 1 "Jun 26, 2017"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
 
 .SH NAME
-keepassxc-cli \- command line interface of \fBKeePassXC\fP
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
 
 .SH SYNOPSIS
 .B keepassxc-cli
-.RI [ options ]
 .I command
+.RI [ options ]
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface of the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, showing the password of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 
-.IP "clip [options] <database> <entry>"
-Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For coping the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name.
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "extract <database>"
-Extracts and prints the contents of a database to standard output.
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
-.IP "list [options] <database> [group]"
-Lists all the entries of a database, or optionally of a single group. The \fI--print-uuids\fP or \fI-u\fP option can also be used, for showing the UUIDs of the entries and the groups.
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
 
 .IP "merge [options] <database1> <database2>"
-Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same password, the \fI--same-password\fP or \fI-s\fP option can be used.
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
-.IP "show <database> <entry>"
-Shows the password of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
-.IP "-g, --gui-prompt"
-Displays a GUI prompt for unlocking the database, instead of directly prompting the user for the password in the command line. Currently, the \fIextract\fP and \fIshow\fP commands do not support this option.
+.SS "General options"
 
-.IP "-u, --print-uuids"
-Prints the UUIDs of the entries and the groups.
+.IP "--debug-info"
+Displays debugging information.
 
-.IP "-s, --same-password"
-Tells the program to use the same password for unlocking both of the database files, in a merge operation.
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
+
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 
 .SH AUTHOR
-This manual page was written by Manolis Agkopian <m.agkopian@gmail.com>.
-
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.

--- a/ubuntu-ppa/cosmic/keepassxc/debian/keepassxc-cli.1
+++ b/ubuntu-ppa/cosmic/keepassxc/debian/keepassxc-cli.1
@@ -1,53 +1,183 @@
-.TH KEEPASSXC-CLI 1 "Jun 26, 2017"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
 
 .SH NAME
-keepassxc-cli \- command line interface of \fBKeePassXC\fP
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
 
 .SH SYNOPSIS
 .B keepassxc-cli
-.RI [ options ]
 .I command
+.RI [ options ]
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface of the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, showing the password of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 
-.IP "clip [options] <database> <entry>"
-Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For coping the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name.
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "extract <database>"
-Extracts and prints the contents of a database to standard output.
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
-.IP "list [options] <database> [group]"
-Lists all the entries of a database, or optionally of a single group. The \fI--print-uuids\fP or \fI-u\fP option can also be used, for showing the UUIDs of the entries and the groups.
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
 
 .IP "merge [options] <database1> <database2>"
-Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same password, the \fI--same-password\fP or \fI-s\fP option can be used.
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
-.IP "show <database> <entry>"
-Shows the password of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
-.IP "-g, --gui-prompt"
-Displays a GUI prompt for unlocking the database, instead of directly prompting the user for the password in the command line. Currently, the \fIextract\fP and \fIshow\fP commands do not support this option.
+.SS "General options"
 
-.IP "-u, --print-uuids"
-Prints the UUIDs of the entries and the groups.
+.IP "--debug-info"
+Displays debugging information.
 
-.IP "-s, --same-password"
-Tells the program to use the same password for unlocking both of the database files, in a merge operation.
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
+
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 
 .SH AUTHOR
-This manual page was written by Manolis Agkopian <m.agkopian@gmail.com>.
-
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.

--- a/ubuntu-ppa/disco/keepassxc/debian/keepassxc-cli.1
+++ b/ubuntu-ppa/disco/keepassxc/debian/keepassxc-cli.1
@@ -1,53 +1,365 @@
-.TH KEEPASSXC-CLI 1 "Jun 26, 2017"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
 
 .SH NAME
-keepassxc-cli \- command line interface of \fBKeePassXC\fP
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
 
 .SH SYNOPSIS
 .B keepassxc-cli
-.RI [ options ]
 .I command
+.RI [ options ]
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface of the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, showing the password of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 
-.IP "clip [options] <database> <entry>"
-Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For coping the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name.
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "extract <database>"
-Extracts and prints the contents of a database to standard output.
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
-.IP "list [options] <database> [group]"
-Lists all the entries of a database, or optionally of a single group. The \fI--print-uuids\fP or \fI-u\fP option can also be used, for showing the UUIDs of the entries and the groups.
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
 
 .IP "merge [options] <database1> <database2>"
-Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same password, the \fI--same-password\fP or \fI-s\fP option can be used.
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
-.IP "show <database> <entry>"
-Shows the password of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
-.IP "-g, --gui-prompt"
-Displays a GUI prompt for unlocking the database, instead of directly prompting the user for the password in the command line. Currently, the \fIextract\fP and \fIshow\fP commands do not support this option.
+.SS "General options"
 
-.IP "-u, --print-uuids"
-Prints the UUIDs of the entries and the groups.
+.IP "--debug-info"
+Displays debugging information.
 
-.IP "-s, --same-password"
-Tells the program to use the same password for unlocking both of the database files, in a merge operation.
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
+
+.SH NAME
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
+
+.SH SYNOPSIS
+.B keepassxc-cli
+.I command
+.RI [ options ]
+
+.SH DESCRIPTION
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
+
+.SH COMMANDS
+
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
+
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
+
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
+
+.IP "merge [options] <database1> <database2>"
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
+
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+
+.SH OPTIONS
+
+.SS "General options"
+
+.IP "--debug-info"
+Displays debugging information.
+
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
+
+.IP "-h, --help"
+Displays help information.
+
+.IP "-v, --version"
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
+
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 
 .SH AUTHOR
-This manual page was written by Manolis Agkopian <m.agkopian@gmail.com>.
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
 
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
+
+.SH AUTHOR
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.

--- a/ubuntu-ppa/trusty/keepassxc/debian/keepassxc-cli.1
+++ b/ubuntu-ppa/trusty/keepassxc/debian/keepassxc-cli.1
@@ -1,53 +1,183 @@
-.TH KEEPASSXC-CLI 1 "Jun 26, 2017"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
 
 .SH NAME
-keepassxc-cli \- command line interface of \fBKeePassXC\fP
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
 
 .SH SYNOPSIS
 .B keepassxc-cli
-.RI [ options ]
 .I command
+.RI [ options ]
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface of the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, showing the password of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 
-.IP "clip [options] <database> <entry>"
-Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For coping the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name.
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "extract <database>"
-Extracts and prints the contents of a database to standard output.
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
-.IP "list [options] <database> [group]"
-Lists all the entries of a database, or optionally of a single group. The \fI--print-uuids\fP or \fI-u\fP option can also be used, for showing the UUIDs of the entries and the groups.
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
 
 .IP "merge [options] <database1> <database2>"
-Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same password, the \fI--same-password\fP or \fI-s\fP option can be used.
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
-.IP "show <database> <entry>"
-Shows the password of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
-.IP "-g, --gui-prompt"
-Displays a GUI prompt for unlocking the database, instead of directly prompting the user for the password in the command line. Currently, the \fIextract\fP and \fIshow\fP commands do not support this option.
+.SS "General options"
 
-.IP "-u, --print-uuids"
-Prints the UUIDs of the entries and the groups.
+.IP "--debug-info"
+Displays debugging information.
 
-.IP "-s, --same-password"
-Tells the program to use the same password for unlocking both of the database files, in a merge operation.
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
+
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 
 .SH AUTHOR
-This manual page was written by Manolis Agkopian <m.agkopian@gmail.com>.
-
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.

--- a/ubuntu-ppa/xenial/keepassxc/debian/keepassxc-cli.1
+++ b/ubuntu-ppa/xenial/keepassxc/debian/keepassxc-cli.1
@@ -1,53 +1,183 @@
-.TH KEEPASSXC-CLI 1 "Jun 26, 2017"
+.TH KEEPASSXC-CLI 1 "Nov 04, 2018"
 
 .SH NAME
-keepassxc-cli \- command line interface of \fBKeePassXC\fP
+keepassxc-cli \- command line interface for the \fBKeePassXC\fP password manager.
 
 .SH SYNOPSIS
 .B keepassxc-cli
-.RI [ options ]
 .I command
+.RI [ options ]
 
 .SH DESCRIPTION
-\fBkeepassxc-cli\fP is the command line interface of the \fBKeePassXC\fP password manager. It provides the ability of listing the entries of a database, showing the password of an entry and many more, directly from the command line.
+\fBkeepassxc-cli\fP is the command line interface for the \fBKeePassXC\fP password manager. It provides the ability to query and modify the entries of a KeePass database, directly from the command line.
 
 .SH COMMANDS
 
-.IP "clip [options] <database> <entry>"
-Copies the password of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For coping the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name.
+.IP "add [options] <database> <entry>"
+Adds a new entry to a database. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
 
-.IP "extract <database>"
-Extracts and prints the contents of a database to standard output.
+.IP "clip [options] <database> <entry> [timeout]"
+Copies the password or the current TOTP (\fI-t\fP option) of a database entry to the clipboard. If multiple entries with the same name exist in different groups, only the password for the first one is going to be copied. For copying the password of an entry in a specific group, the group path to the entry should be specified as well, instead of just the name. Optionally, a timeout in seconds can be specified to automatically clear the clipboard.
 
-.IP "entropy-meter [-a pwd1 pwd2 ...]"
-Calculates the entropy of a single or multiple passwords specified using the \fI-a\fP option. If no passwords are specified, the program will run in interactive mode and prompt the user to enter a password.
+.IP "create [options] <database>"
+Creates a new database with a key file and/or password. The key file will be created if the file that is referred to does not exist. If both the key file and password are empty, no database will be created.
 
-.IP "list [options] <database> [group]"
-Lists all the entries of a database, or optionally of a single group. The \fI--print-uuids\fP or \fI-u\fP option can also be used, for showing the UUIDs of the entries and the groups.
+.IP "diceware [options]"
+Generate a random diceware passphrase.
+
+.IP "edit [options] <database> <entry>"
+Edits a database entry. A password can be generated (\fI-g\fP option), or a prompt can be displayed to input the password (\fI-p\fP option).
+
+.IP "estimate [options] [password]"
+Estimates the entropy of a password. The password to estimate can be provided as a positional argument, or using the standard input.
+
+.IP "extract [options] <database>"
+Extracts and prints the contents of a database to standard output in XML format.
+
+.IP "generate [options]"
+Generate a random password.
+
+.IP "locate [options] <database> <term>"
+Locates all the entries that match a specific search term in a database.
+
+.IP "ls [options] <database> [group]"
+Lists the contents of a group in a database. If no group is specified, it will default to the root group.
 
 .IP "merge [options] <database1> <database2>"
-Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same password, the \fI--same-password\fP or \fI-s\fP option can be used.
+Merges two databases together. The first database file is going to be replaced by the result of the merge, for that reason it is advisable to keep a backup of the two database files before attempting a merge. In the case that both databases make use of the same credentials, the \fI--same-credentials\fP or \fI-s\fP option can be used.
 
-.IP "show <database> <entry>"
-Shows the password of a database entry. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
+.IP "rm [options] <database> <entry>"
+Removes an entry from a database. If the database has a recycle bin, the entry will be moved there. If the entry is already in the recycle bin, it will be removed permanently.
+
+.IP "show [options] <database> <entry>"
+Shows the title, username, password, URL and notes of a database entry. Can also show the current TOTP. Regarding the occurrence of multiple entries with the same name in different groups, everything stated in the \fIclip\fP command section also applies here.
 
 .SH OPTIONS
 
-.IP "-g, --gui-prompt"
-Displays a GUI prompt for unlocking the database, instead of directly prompting the user for the password in the command line. Currently, the \fIextract\fP and \fIshow\fP commands do not support this option.
+.SS "General options"
 
-.IP "-u, --print-uuids"
-Prints the UUIDs of the entries and the groups.
+.IP "--debug-info"
+Displays debugging information.
 
-.IP "-s, --same-password"
-Tells the program to use the same password for unlocking both of the database files, in a merge operation.
+.IP "-k, --key-file <path>"
+Specifies a path to a key file for unlocking the database. In a merge operation this option is used to specify the key file path for the first database.
+
+.IP "--no-password"
+Deactivate password key for the database.
+
+.IP "-q, --quiet <path>"
+Silence password prompt and other secondary outputs.
 
 .IP "-h, --help"
 Displays help information.
 
 .IP "-v, --version"
-Shows the program version.
+Displays the program version.
+
+
+.SS "Merge options"
+
+.IP "-f, --key-file-from <path>"
+Path of the key file for the second database.
+
+.IP "--no-password-from"
+Deactivate password key for the database to merge from.
+
+.IP "-s, --same-credentials"
+Use the same credentials for unlocking both database.
+
+
+.SS "Add and edit options"
+
+.IP "-u, --username <username>"
+Specify the username of the entry.
+
+.IP "--url <url>"
+Specify the URL of the entry.
+
+.IP "-p, --password-prompt"
+Use a password prompt for the entry's password.
+
+.IP "-g, --generate"
+Generate a new password for the entry.
+
+.IP "-l, --password-length"
+Specify the length of the password to generate.
+
+
+.SS "Edit options"
+
+.IP "-t, --title <title>"
+Specify the title of the entry.
+
+
+.SS "Estimate options"
+
+.IP "-a, --advanced"
+Perform advanced analysis on the password.
+
+
+.SS "Clip options"
+
+.IP "-t, --totp"
+Copy the current TOTP instead of current password to clipboard. Will report an error
+if no TOTP is configured for the entry.
+
+
+.SS "Show options"
+
+.IP "-a, --attributes <attribute>..."
+Names of the attributes to show. This option can be specified more than once,
+with each attribute shown one-per-line in the given order. If no attributes are
+specified and \fI-t\fP is not specified, a summary of the default attributes is given.
+
+.IP "-t, --totp"
+Also show the current TOTP. Will report an error if no TOTP is configured for the
+entry.
+
+
+.SS "Diceware options"
+
+.IP "-W, --words <count>"
+Desired number of words for the generated passphrase. [Default: 7]
+
+.IP "-w, --word-list <path>"
+Path of the wordlist for the diceware generator. The wordlist must have > 1000 words,
+otherwise the program will fail. If the wordlist has < 4000 words a warning will
+be printed to STDERR.
+
+
+.SS "List options"
+
+.IP "-R, --recursive"
+Recursively list the elements of the group.
+
+
+.SS "Generate options"
+
+.IP "-L, --length <length>"
+Desired length for the generated password. [Default: 16]
+
+.IP "-l"
+Use lowercase characters for the generated password. [Default: Enabled]
+
+.IP "-u"
+Use uppercase characters for the generated password. [Default: Enabled]
+
+.IP "-n"
+Use numbers characters for the generated password. [Default: Enabled]
+
+.IP "-s"
+Use special characters for the generated password. [Default: Disabled]
+
+.IP "-e"
+Use extended ASCII characters for the generated password. [Default: Disabled]
+
+
+
+.SH REPORTING BUGS
+Bugs and feature requests can be reported on GitHub at https://github.com/keepassxreboot/keepassxc/issues.
 
 .SH AUTHOR
-This manual page was written by Manolis Agkopian <m.agkopian@gmail.com>.
-
+This manual page was originally written by Manolis Agkopian <m.agkopian@gmail.com>,
+and is maintained by the KeePassXC Team <team@keepassxc.org>.


### PR DESCRIPTION
Fixes this issue - https://github.com/keepassxreboot/keepassxc/issues/2219

The PPA was shipping an older version of the keepassxc-cli.1 file which was resulting in a mismatch between `keepassxc-cli -h` and `man keepassxc-cli`. 

I have updated the keepassxc-cli.1 file to match the one in the repo [here](https://github.com/keepassxreboot/keepassxc/blob/develop/src/cli/keepassxc-cli.1)

Thanks